### PR TITLE
Path fixes

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -29,7 +29,8 @@ module.exports = function(grunt) {
       bower: {
         files: [
           {
-            'build/vendor/phaser.min.js': 'app/vendor/phaser-official/build/phaser.min.js'
+            'build/vendor/phaser.min.js': 'app/vendor/phaser-official/build/phaser.min.js',
+            'build/vendor/phaser.map': 'app/vendor/phaser-official/build/phaser.map'
           }
         ]
       }

--- a/app/templates/app/scripts/_Game.ts
+++ b/app/templates/app/scripts/_Game.ts
@@ -1,4 +1,4 @@
-/// <reference path="../vendor/phaser-official/build/phaser.d.ts"/>
+/// <reference path="../vendor/phaser-official/typescript/phaser.d.ts"/>
 
 /// <reference path='State/Boot.ts'/>
 /// <reference path='State/Preload.ts'/>


### PR DESCRIPTION
Hi,

I've made two path fixes as per suggestion from user Elzean here: https://github.com/rcolinray/generator-phaser-typescript/issues/3

The change to the Gruntfile.js is to copy the Phaser source map to the build folder so that the browser can find it without a 404 error.

The change to the Game.ts file is to fix a broken reference to the Phaser Typescript definition file - otherwise a Typescript compiler error is raised when the project is built with grunt.

Thanks
